### PR TITLE
支持自定义库路径

### DIFF
--- a/src/main/java/com/taosdata/jdbc/TSDBJNIConnector.java
+++ b/src/main/java/com/taosdata/jdbc/TSDBJNIConnector.java
@@ -5,6 +5,7 @@ import com.taosdata.jdbc.enums.SchemalessProtocolType;
 import com.taosdata.jdbc.enums.SchemalessTimestampType;
 import com.taosdata.jdbc.utils.TaosInfo;
 
+import java.io.File;
 import java.io.UnsupportedEncodingException;
 import java.nio.ByteBuffer;
 import java.sql.SQLException;
@@ -32,7 +33,30 @@ public class TSDBJNIConnector {
     private int affectedRows = -1;
 
     static {
-        System.loadLibrary("taos");
+        boolean loaded = false;
+        try {
+            String lp = System.getProperty("taos.library.path");
+
+            if (lp == null) {
+                System.getenv("TAOS_LIBRARY_PATH");
+            }
+
+            if (lp != null) {
+                File lib = new File(lp);
+                if (lib.exists()
+                    && lib.isFile()
+                    && lib.canRead()) {
+                    System.load(lp);
+                    loaded = true;
+                }
+            }
+        } finally {
+            if (!loaded) {
+                // todo print warning?
+                // fallback to system library
+                System.loadLibrary("taos");
+            }
+        }
     }
 
     /***********************************************************************/


### PR DESCRIPTION
变更说明：
1. 增加JVM参数`taos.library.path`， 环境变量`TAOS_LIBRARY_PATH`传入lib文件的路径(支持绝对路径和相对路径)。
2. 若用户未配置JVM参数或环境变量， 则回落调用`System#loadLibrary`方法
2. 参数优先级， JVM参数>环境变量